### PR TITLE
Fixed markdown inline code color

### DIFF
--- a/rose-pine-dawn.xccolortheme
+++ b/rose-pine-dawn.xccolortheme
@@ -45,7 +45,7 @@
 	<key>DVTMarkupTextEmphasisFont</key>
 	<string>.AppleSystemUIFontItalic - 10.0</string>
 	<key>DVTMarkupTextInlineCodeColor</key>
-	<string>0 0 0 0.7</string>
+	<string>0.156863 0.411765 0.513725 1</string>
 	<key>DVTMarkupTextLinkColor</key>
 	<string>0 0 1 1</string>
 	<key>DVTMarkupTextLinkFont</key>

--- a/rose-pine-moon.xccolortheme
+++ b/rose-pine-moon.xccolortheme
@@ -45,7 +45,7 @@
 	<key>DVTMarkupTextEmphasisFont</key>
 	<string>.SFNS-RegularItalic - 11.0</string>
 	<key>DVTMarkupTextInlineCodeColor</key>
-	<string>0 0 0 0.7</string>
+	<string>0.768627 0.654902 0.905882 1</string>
 	<key>DVTMarkupTextLinkColor</key>
 	<string>0 0 0.8 1</string>
 	<key>DVTMarkupTextLinkFont</key>

--- a/rose-pine.xccolortheme
+++ b/rose-pine.xccolortheme
@@ -43,7 +43,7 @@
 	<key>DVTMarkupTextEmphasisFont</key>
 	<string>.SFNS-RegularItalic - 10.0</string>
 	<key>DVTMarkupTextInlineCodeColor</key>
-	<string>0 0 0 0.7</string>
+	<string>0.768627 0.654902 0.905882 1</string>
 	<key>DVTMarkupTextLinkColor</key>
 	<string>0 0 0.8 1</string>
 	<key>DVTMarkupTextLinkFont</key>


### PR DESCRIPTION
The color for markdown code was set to black. I updated it to be Iris